### PR TITLE
Representation size adjustment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ rust-version = "1.79"
 [dependencies]
 primeorder = { version = "0.13", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-ecdsa = { version = "0.16", default-features = false, features = ["arithmetic", "digest", "hazmat"] }
+ecdsa = { version = "0.16", default-features = false, features = ["signing", "verifying"] }
 sha2 = { version = "0.10", default-features = false }
-
 
 # Optional dependencies
 serde = { version = "1", optional = true, default-features = false }

--- a/src/curve16.rs
+++ b/src/curve16.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u16> for Modulus<u16, ORDER> {
 pub struct TinyCurve16;
 
 impl Curve for TinyCurve16 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve16 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve16;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve16;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve16 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve16>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/curve32.rs
+++ b/src/curve32.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u32> for Modulus<u32, ORDER> {
 pub struct TinyCurve32;
 
 impl Curve for TinyCurve32 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve32 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve32;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve32;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve32 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve32>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/curve64.rs
+++ b/src/curve64.rs
@@ -1,13 +1,11 @@
 use primeorder::{
-    elliptic_curve::{
-        bigint::U64, generic_array::typenum, Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding,
-    },
+    elliptic_curve::{Curve, CurveArithmetic, FieldBytes, FieldBytesEncoding},
     point_arithmetic::EquationAIsMinusThree,
     AffinePoint, PrimeCurve, PrimeCurveParams, ProjectivePoint,
 };
 
 use crate::{
-    prime_field::FieldElement,
+    prime_field::{FieldElement, ReprSizeTypenum, ReprUint},
     traits::{Modulus, PrimeFieldConstants},
 };
 
@@ -47,8 +45,8 @@ impl PrimeFieldConstants<u64> for Modulus<u64, ORDER> {
 pub struct TinyCurve64;
 
 impl Curve for TinyCurve64 {
-    type FieldBytesSize = typenum::U8;
-    type Uint = U64;
+    type FieldBytesSize = ReprSizeTypenum;
+    type Uint = ReprUint;
     const ORDER: Self::Uint = Self::Uint::from_u64(ORDER);
 }
 
@@ -76,13 +74,14 @@ impl PrimeCurveParams for TinyCurve64 {
 
 #[cfg(test)]
 mod tests {
-    use super::TinyCurve64;
     use primeorder::elliptic_curve::{
-        bigint::U64,
         ops::{MulByGenerator, Reduce},
         CurveArithmetic, ProjectivePoint,
     };
     use proptest::prelude::*;
+
+    use super::TinyCurve64;
+    use crate::prime_field::ReprUint;
 
     type Scalar = <TinyCurve64 as CurveArithmetic>::Scalar;
     type Point = ProjectivePoint<TinyCurve64>;
@@ -90,7 +89,7 @@ mod tests {
     prop_compose! {
         /// Generate a random odd modulus.
         fn scalar()(n in any::<u64>()) -> Scalar {
-            Scalar::reduce(U64::from(n))
+            Scalar::reduce(ReprUint::from(n))
         }
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -8,15 +8,7 @@ use primeorder::elliptic_curve::subtle::{ConditionallySelectable, ConstantTimeEq
 use crate::reciprocal::{rem_wide_with_reciprocal, Reciprocal};
 
 pub trait PrimeFieldConstants<T> {
-    type Repr: AsRef<[u8]>
-        + AsMut<[u8]>
-        + Send
-        + Sync
-        + Default
-        + Clone
-        + Copy
-        + From<[u8; 8]>
-        + Into<[u8; 8]>;
+    type Repr: AsRef<[u8]> + AsMut<[u8]> + Send + Sync + Default + Clone + Copy;
     const MODULUS_STR: &'static str;
     const MODULUS: T;
     const NUM_BITS: u32;


### PR DESCRIPTION
- Use `U192` as the external representation. This is the smallest type that implements [`ModulusSize`](https://docs.rs/elliptic-curve/0.13.8/elliptic_curve/sec1/trait.ModulusSize.html) which we need for [`FromEncodedPoint`](https://docs.rs/elliptic-curve/0.13.8/elliptic_curve/sec1/trait.FromEncodedPoint.html).
- Remove size hardcoding throughout the code.
- Add missing verifying traits and expand the ECDSA sign/verify test.

It slows down `mul_by_generator()` considerably, should be fixed by https://github.com/RustCrypto/elliptic-curves/pull/1119.