### PR TITLE
Fix `from_repr()` behavior for values between `M` and `u64::MAX`

### DIFF
--- a/src/curve16.rs
+++ b/src/curve16.rs
@@ -102,9 +102,14 @@ impl AssociatedOid for TinyCurve16 {
 
 #[cfg(test)]
 mod tests {
-    use primeorder::elliptic_curve::{
-        ops::{MulByGenerator, Reduce},
-        CurveArithmetic, Field, ProjectivePoint,
+    use primeorder::{
+        elliptic_curve::{
+            bigint::Encoding,
+            generic_array::GenericArray,
+            ops::{MulByGenerator, Reduce},
+            CurveArithmetic, Field, FieldBytesSize, ProjectivePoint,
+        },
+        PrimeField,
     };
     use proptest::prelude::*;
     use rand_core::OsRng;
@@ -121,6 +126,28 @@ mod tests {
         let y = Scalar::ZERO - x;
         let p = Point::mul_by_generator(&x) + Point::mul_by_generator(&y);
         assert_eq!(p, Point::IDENTITY);
+    }
+
+    #[test]
+    fn to_and_from_repr() {
+        let mut repr = GenericArray::<u8, FieldBytesSize<TinyCurve16>>::default();
+
+        // `s` now contains the value `M - 1`.
+        let s = -Scalar::new_unchecked(1);
+        let s_uint: ReprUint = s.into();
+
+        // Check that to_repr/from_repr work normally
+        let s_uint_repr = s_uint.to_be_bytes();
+        repr.copy_from_slice(&s_uint_repr);
+        let s_repr = s.to_repr();
+        assert_eq!(repr, s_repr);
+        assert_eq!(Scalar::from_repr(repr).unwrap(), s);
+
+        // Now construct a representation of the value `M` (which would be out of range)
+        let x_uint = s_uint.wrapping_add(&ReprUint::ONE);
+        let x_uint_repr = x_uint.to_be_bytes();
+        repr.copy_from_slice(&x_uint_repr);
+        assert!(bool::from(Scalar::from_repr(repr).is_none()));
     }
 
     prop_compose! {

--- a/src/curve64.rs
+++ b/src/curve64.rs
@@ -102,9 +102,14 @@ impl AssociatedOid for TinyCurve64 {
 
 #[cfg(test)]
 mod tests {
-    use primeorder::elliptic_curve::{
-        ops::{MulByGenerator, Reduce},
-        CurveArithmetic, Field, ProjectivePoint,
+    use primeorder::{
+        elliptic_curve::{
+            bigint::Encoding,
+            generic_array::GenericArray,
+            ops::{MulByGenerator, Reduce},
+            CurveArithmetic, Field, FieldBytesSize, ProjectivePoint,
+        },
+        PrimeField,
     };
     use proptest::prelude::*;
     use rand_core::OsRng;
@@ -121,6 +126,28 @@ mod tests {
         let y = Scalar::ZERO - x;
         let p = Point::mul_by_generator(&x) + Point::mul_by_generator(&y);
         assert_eq!(p, Point::IDENTITY);
+    }
+
+    #[test]
+    fn to_and_from_repr() {
+        let mut repr = GenericArray::<u8, FieldBytesSize<TinyCurve64>>::default();
+
+        // `s` now contains the value `M - 1`.
+        let s = -Scalar::new_unchecked(1);
+        let s_uint: ReprUint = s.into();
+
+        // Check that to_repr/from_repr work normally
+        let s_uint_repr = s_uint.to_be_bytes();
+        repr.copy_from_slice(&s_uint_repr);
+        let s_repr = s.to_repr();
+        assert_eq!(repr, s_repr);
+        assert_eq!(Scalar::from_repr(repr).unwrap(), s);
+
+        // Now construct a representation of the value `M` (which would be out of range)
+        let x_uint = s_uint.wrapping_add(&ReprUint::ONE);
+        let x_uint_repr = x_uint.to_be_bytes();
+        repr.copy_from_slice(&x_uint_repr);
+        assert!(bool::from(Scalar::from_repr(repr).is_none()));
     }
 
     prop_compose! {

--- a/src/prime_field.rs
+++ b/src/prime_field.rs
@@ -519,8 +519,17 @@ where
         let high_bits_are_zero = repr.as_ref()[..repr_len - DATA_SIZE]
             .iter()
             .all(|x| x == &0);
-        let within_range = Choice::from((high_bits_are_zero && value < M) as u8);
-        CtOption::new(Self::new_unchecked_u64(value), within_range)
+
+        let within_range = high_bits_are_zero && value < M;
+
+        // If the value is not within [0, M), avoid triggering debug checks in `new_unchecked_u64`,
+        // and make it more clear that the value is invalid.
+        let value = if within_range { value } else { 0 };
+
+        CtOption::new(
+            Self::new_unchecked_u64(value),
+            Choice::from(within_range as u8),
+        )
     }
 
     fn to_repr(&self) -> Self::Repr {


### PR DESCRIPTION
The problem was that, while it correctly created a falsy `CtOption`, it used the invalid value (which you have to provide, since it's a constant-time structure), which triggered a debug assert. This PR replaces the value with 0 if it is out of range.